### PR TITLE
Add basic React memory training app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "kurzzeitgedaechtnis-trainer",
+  "version": "1.0.0",
+  "description": "Web-App zum Training des Kurzzeitgedächtnisses",
+  "scripts": {
+    "start": "npx serve -s public",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kurzzeitgedächtnis Trainer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="root"></div>
+
+  <!-- React and Babel from CDN -->
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+
+  <script type="text/babel" src="../src/index.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,27 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: #f8f9fa;
+}
+
+h1 {
+  text-align: center;
+}
+
+.container {
+  max-width: 800px;
+  margin: auto;
+  padding: 20px;
+}
+
+button {
+  padding: 10px 20px;
+  margin: 5px;
+  font-size: 16px;
+}
+
+.score {
+  font-size: 18px;
+  margin-top: 10px;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,126 @@
+function App() {
+  const [currentExercise, setCurrentExercise] = React.useState(null);
+
+  const renderExercise = () => {
+    switch (currentExercise) {
+      case 'loci':
+        return <LociExercise />;
+      case 'nback':
+        return <NBackExercise />;
+      case 'sequence':
+        return <SequenceExercise />;
+      default:
+        return (
+          <div>
+            <h2>Wähle eine Übung:</h2>
+            <button onClick={() => setCurrentExercise('loci')}>Gedächtnispalast</button>
+            <button onClick={() => setCurrentExercise('nback')}>N-Back</button>
+            <button onClick={() => setCurrentExercise('sequence')}>Sequenztraining</button>
+          </div>
+        );
+    }
+  };
+
+  return (
+    <div className="container">
+      <h1>Kurzzeitgedächtnis Trainer</h1>
+      {renderExercise()}
+    </div>
+  );
+}
+
+function LociExercise() {
+  const [items, setItems] = React.useState(['Apfel', 'Buch', 'Kerze']);
+  const [step, setStep] = React.useState(0);
+  const [answer, setAnswer] = React.useState('');
+  const [score, setScore] = React.useState(0);
+
+  const handleSubmit = () => {
+    if (answer.trim().toLowerCase() === items[step].toLowerCase()) {
+      setScore(score + 1);
+    }
+    setAnswer('');
+    if (step < items.length - 1) {
+      setStep(step + 1);
+    } else {
+      alert(`Fertig! Punkte: ${score}`);
+      setStep(0);
+      setScore(0);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Loci Methode</h2>
+      <p>Merke dir die Position des folgenden Objekts in deinem Gedächtnispalast:</p>
+      <h3>{items[step]}</h3>
+      <input value={answer} onChange={e => setAnswer(e.target.value)} placeholder="Objekt eingeben" />
+      <button onClick={handleSubmit}>Bestätigen</button>
+      <p className="score">Punkte: {score}</p>
+    </div>
+  );
+}
+
+function NBackExercise() {
+  const sequence = ['A', 'B', 'A', 'C', 'B', 'C'];
+  const [index, setIndex] = React.useState(0);
+  const [score, setScore] = React.useState(0);
+
+  const handleYes = () => {
+    if (index >= 2 && sequence[index] === sequence[index - 2]) {
+      setScore(score + 1);
+    }
+    next();
+  };
+
+  const handleNo = () => {
+    next();
+  };
+
+  const next = () => {
+    if (index < sequence.length - 1) {
+      setIndex(index + 1);
+    } else {
+      alert(`Fertig! Punkte: ${score}`);
+      setIndex(0);
+      setScore(0);
+    }
+  };
+
+  return (
+    <div>
+      <h2>N-Back Training (2-back)</h2>
+      <h3>{sequence[index]}</h3>
+      <button onClick={handleYes}>Wiederholt</button>
+      <button onClick={handleNo}>Neu</button>
+      <p className="score">Punkte: {score}</p>
+    </div>
+  );
+}
+
+function SequenceExercise() {
+  const [sequence, setSequence] = React.useState([1, 4, 3]);
+  const [answer, setAnswer] = React.useState('');
+  const [score, setScore] = React.useState(0);
+
+  const handleSubmit = () => {
+    if (answer === sequence.join('')) {
+      setScore(score + 1);
+    }
+    setAnswer('');
+    const nextSeq = [...sequence, Math.floor(Math.random() * 9) + 1];
+    setSequence(nextSeq);
+  };
+
+  return (
+    <div>
+      <h2>Sequenztraining</h2>
+      <h3>{sequence.join(' ')}</h3>
+      <input value={answer} onChange={e => setAnswer(e.target.value)} placeholder="Sequenz wiederholen" />
+      <button onClick={handleSubmit}>Bestätigen</button>
+      <p className="score">Punkte: {score}</p>
+    </div>
+  );
+}
+
+export default App;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import App from './App.js';
+
+ReactDOM.render(
+  <App />,
+  document.getElementById('root')
+);


### PR DESCRIPTION
## Summary
- scaffold simple React-based short-term memory trainer
- add three exercises (Loci-Methode, N-back and Sequenztraining)
- provide minimal HTML/CSS for running the app in a browser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d822dbaf4832e9f63567e7be53d43