### PR TITLE
Fix blank page by loading App component without module imports

### DIFF
--- a/public/App.js
+++ b/public/App.js
@@ -123,4 +123,3 @@ function SequenceExercise() {
   );
 }
 
-export default App;

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,8 @@
   <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
   <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
 
+  <!-- Lade die Komponenten-Datei vor dem Einstiegspunkt -->
+  <script type="text/babel" src="App.js"></script>
   <script type="text/babel" src="index.js"></script>
 </body>
 </html>

--- a/public/index.js
+++ b/public/index.js
@@ -1,5 +1,3 @@
-import App from './App.js';
-
 ReactDOM.render(
   <App />,
   document.getElementById('root')


### PR DESCRIPTION
## Summary
- register `App.js` as a script and drop module import/export
- render the `App` component directly

## Testing
- `npm test`
- `npm start` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685da91c16f8832e9785318bdb7e477a